### PR TITLE
Fix checkout, close a free-plan hole, and stop shipping a published SECRET_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ STRIPE_PUBLIC_KEY=your-stripe-publishable-key
 STRIPE_SECRET_KEY=your-stripe-secret-key
 STRIPE_WEBHOOK_SECRET=your-stripe-webhook-secret
 STRIPE_PRICE_ID=your-stripe-price-id
+# Pinned so an SDK upgrade cannot change response shapes under you.
+# STRIPE_API_VERSION=2026-08-26.dahlia
 
 # Security Settings
 CSRF_TRUSTED_ORIGINS=http://localhost:8000,https://yourdomain.com

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # Django Settings
+# Development only. Copying this file to a server as-is leaves DEBUG on, which
+# turns off every production security setting AND lets the app start with the
+# development SECRET_KEY below. Set DEBUG=False and a real SECRET_KEY there.
 DEBUG=True
 SECRET_KEY=your-secret-key-here
 ALLOWED_HOSTS=localhost,127.0.0.1

--- a/Makefile
+++ b/Makefile
@@ -1,31 +1,40 @@
+# Every target runs through the virtualenv that `install` creates. Calling a
+# bare `python` here is why five of these used to fail on a fresh clone: the
+# venv existed and nothing ever used it.
+VENV := venv
+PY := $(VENV)/bin/python
+
 .PHONY: install run migrate test superuser lint format seed clean
 
 install:
-	python3 -m venv venv
-	./venv/bin/pip install -r requirements.txt
+	python3 -m venv $(VENV)
+	$(VENV)/bin/pip install --upgrade pip
+	$(VENV)/bin/pip install -r requirements.txt
+	@echo ""
+	@echo "Done. Next: cp .env.example .env && make migrate && make run"
 
 run:
-	python manage.py runserver
+	$(PY) manage.py runserver
 
 migrate:
-	python manage.py makemigrations
-	python manage.py migrate
+	$(PY) manage.py makemigrations
+	$(PY) manage.py migrate
 
 test:
-	python manage.py test
+	$(PY) manage.py test
 
 superuser:
-	python manage.py createsuperuser
+	$(PY) manage.py createsuperuser
 
 lint:
-	ruff check .
+	$(VENV)/bin/ruff check .
 
 format:
-	ruff format .
+	$(VENV)/bin/ruff format .
 
 seed:
-	python manage.py seed_data
+	$(PY) manage.py seed_data
 
 clean:
-	find . -type d -name __pycache__ -not -path "./venv/*" -exec rm -rf {} +
-	find . -type f -name "*.pyc" -not -path "./venv/*" -delete
+	find . -type d -name __pycache__ -not -path "./$(VENV)/*" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -not -path "./$(VENV)/*" -delete

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The open-source Django starter kit for building SaaS applications. Auth, payments, dashboard, and deployment — all wired up.
 
 <div align="center">
-  <img src="https://img.shields.io/badge/Django-6.0-092E20?style=for-the-badge&logo=django&logoColor=white" alt="Django"/>
+  <img src="https://img.shields.io/badge/Django-6.0%2B-092E20?style=for-the-badge&logo=django&logoColor=white" alt="Django"/>
   <img src="https://img.shields.io/badge/Python-3.12-3776AB?style=for-the-badge&logo=python&logoColor=white" alt="Python"/>
   <img src="https://img.shields.io/badge/Tailwind_CSS-CDN-38B2AC?style=for-the-badge&logo=tailwind-css&logoColor=white" alt="Tailwind CSS"/>
   <img src="https://img.shields.io/badge/Stripe-Payments-6772E5?style=for-the-badge&logo=stripe&logoColor=white" alt="Stripe"/>
@@ -46,10 +46,11 @@ Worth knowing before you build on it, so you can decide what to add yourself:
 - **No plan gating.** `SubscriptionPlan.features` is a JSON list for the pricing
   page — marketing copy, not entitlements. Nothing in the code stops a free user
   from using a paid feature, and there are no usage counters or quotas.
-- **Two places track a subscription.** `StripeCustomer` mirrors Stripe;
-  `UserSettings` holds the plan and trial the dashboard reads. Nothing
-  reconciles them, so the dashboard's manual plan/trial actions do not touch
-  Stripe. Wiring them together is left to you.
+- **Two places still track a subscription.** `StripeCustomer` mirrors Stripe;
+  `UserSettings` holds what the dashboard gates on. Paying now grants access and
+  cancelling cancels at Stripe, so the money and the access agree — but they are
+  still two records kept in step by one function, not one model. Anything past
+  that (per-plan entitlements, seats, usage counters) starts from scratch.
 - **Minimal billing lifecycle.** The webhook handles subscription
   created/updated/deleted. No failed-payment recovery, no customer portal, no
   invoice history.
@@ -65,7 +66,7 @@ MIT licensed. Fork it, rename it, ship it, sell it — no attribution required.
 
 | Layer | Technology |
 |-------|-----------|
-| Backend | Django 6.0, Python 3.12 |
+| Backend | Django 6.0+, Python 3.12 |
 | Auth | django-allauth (email-only) |
 | Payments | Stripe (Payment Methods API) |
 | Frontend | Tailwind CSS (CDN), Alpine.js, HTMX |
@@ -77,15 +78,25 @@ MIT licensed. Fork it, rename it, ship it, sell it — no attribution required.
 
 ## Quick start
 
+Requires **Python 3.12+**. On Debian or Ubuntu you also need the venv package,
+or `make install` fails with `ensurepip is not available`:
+
+```bash
+sudo apt install python3.12-venv
+```
+
 ```bash
 git clone https://github.com/eriktaveras/django-saas-boilerplate.git
 cd django-saas-boilerplate
 make install
 cp .env.example .env
 make migrate
-python manage.py seed_data
+make seed
 make run
 ```
+
+Every `make` target runs through the virtualenv that `make install` creates, so
+there is nothing to activate.
 
 Visit **http://localhost:8000**. `seed_data` prints the generated admin password once — copy it from the terminal. Set `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` to choose your own.
 
@@ -171,7 +182,7 @@ STRIPE_PRICE_ID=price_...
 # EMAIL_HOST_PASSWORD=your-app-password
 ```
 
-## Django 6.0 features used
+## Django 6.0+ features used
 
 This boilerplate uses two features introduced in Django 6.0:
 
@@ -219,9 +230,15 @@ heroku run python manage.py migrate
 ```bash
 pip install -r requirements.txt
 python manage.py migrate
-python manage.py collectstatic
-gunicorn core.wsgi --bind 0.0.0.0:8000
+python manage.py collectstatic --noinput
+gunicorn core.wsgi --bind 127.0.0.1:8000
 ```
+
+Bind to localhost and put nginx or Caddy in front, terminating TLS. The app
+trusts the `X-Forwarded-Proto` header to decide whether a request arrived over
+HTTPS, which is what platforms like Railway and Heroku set. Exposing gunicorn
+directly on `0.0.0.0` lets a client send that header itself and walk straight
+past `SECURE_SSL_REDIRECT`.
 
 ## If you need the other half
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Everything below works out of the box.
 - **Static files** — WhiteNoise, no nginx needed
 - **Deployment** — Gunicorn + Procfile, ready for Railway/Heroku/VPS
 - **Linting** — Ruff with Django-specific rules
-- **29 tests** — landing pages, auth, dashboard, models, Stripe checkout and webhook
+- **46 tests** — landing pages, auth, dashboard, models, Stripe checkout and webhook
 - **Seed data** — one command to populate demo data
 
 ## What it does not do
@@ -87,7 +87,7 @@ python manage.py seed_data
 make run
 ```
 
-Visit **http://localhost:8000** — admin login: `admin@example.com` / `admin123`
+Visit **http://localhost:8000**. `seed_data` prints the generated admin password once — copy it from the terminal. Set `SEED_ADMIN_EMAIL` / `SEED_ADMIN_PASSWORD` to choose your own.
 
 ## Commands
 
@@ -96,7 +96,7 @@ Visit **http://localhost:8000** — admin login: `admin@example.com` / `admin123
 | `make install` | Create virtualenv and install dependencies |
 | `make run` | Start development server |
 | `make migrate` | Run makemigrations + migrate |
-| `make test` | Run 29 tests |
+| `make test` | Run 46 tests |
 | `make seed` | Populate demo data (admin + plans) |
 | `make lint` | Lint with ruff |
 | `make format` | Format with ruff |
@@ -212,7 +212,6 @@ heroku config:set SECRET_KEY=your-secret-key
 heroku config:set DEBUG=False
 git push heroku main
 heroku run python manage.py migrate
-heroku run python manage.py seed_data
 ```
 
 ### VPS

--- a/README.md
+++ b/README.md
@@ -12,23 +12,54 @@ The open-source Django starter kit for building SaaS applications. Auth, payment
 
 ---
 
-## What's included
+## What this is
+
+A small, finished SaaS starter. Sign up, log in, land on a dashboard, pay with a
+card, and there is a public site in front of it. That is the whole scope, and it
+is deliberate: it is what you need on a Saturday morning to stop configuring and
+start building the thing you actually wanted to build.
+
+Everything below works out of the box.
 
 - **Custom user model** — email-only login, no username
-- **Authentication** — signup, login, email verification, password reset (django-allauth)
-- **Stripe subscriptions** — Payment Methods API, webhooks, subscription status tracking
-- **User dashboard** — sidebar nav, profile, settings, notification preferences, API keys
+- **Authentication** — signup, login, email verification, password reset (django-allauth), 21 styled templates
+- **Stripe subscriptions** — Payment Methods API, pinned API version, signed webhook, subscription status on the user
+- **User dashboard** — sidebar nav, profile, notification settings, API key generation (hashed, shown once)
 - **Subscription plans** — admin-managed plans with trial support
-- **Background tasks** — Django 6.0 native `@task()` decorator, no Celery needed
-- **Content Security Policy** — Django 6.0 built-in CSP middleware with nonces
-- **Template partials** — Django 6.0 `{% partialdef %}` for reusable components
+- **Landing pages** — home, features, pricing, `robots.txt`
+- **Background tasks** — Django 6.0 native `@task()`, no Celery
+- **Content Security Policy** — Django 6.0 CSP middleware with nonces
 - **Security headers** — HSTS, SSL redirect, secure cookies (auto-enabled in production)
 - **PostgreSQL support** — `DATABASE_URL` with SQLite fallback
 - **Static files** — WhiteNoise, no nginx needed
 - **Deployment** — Gunicorn + Procfile, ready for Railway/Heroku/VPS
 - **Linting** — Ruff with Django-specific rules
-- **16 tests** — landing pages, auth, dashboard, models
+- **29 tests** — landing pages, auth, dashboard, models, Stripe checkout and webhook
 - **Seed data** — one command to populate demo data
+
+## What it does not do
+
+Worth knowing before you build on it, so you can decide what to add yourself:
+
+- **No teams or multi-tenancy.** One user, one account. There is no concept of
+  an organisation, a member, or a role.
+- **No plan gating.** `SubscriptionPlan.features` is a JSON list for the pricing
+  page — marketing copy, not entitlements. Nothing in the code stops a free user
+  from using a paid feature, and there are no usage counters or quotas.
+- **Two places track a subscription.** `StripeCustomer` mirrors Stripe;
+  `UserSettings` holds the plan and trial the dashboard reads. Nothing
+  reconciles them, so the dashboard's manual plan/trial actions do not touch
+  Stripe. Wiring them together is left to you.
+- **Minimal billing lifecycle.** The webhook handles subscription
+  created/updated/deleted. No failed-payment recovery, no customer portal, no
+  invoice history.
+- **No REST API.** The dashboard mints and hashes an API key, but nothing
+  authenticates with it yet — it is a starting point, not an API.
+- **Tailwind and Alpine come from a CDN.** No build step, which is why setup is
+  one command. Before production you will want a real Tailwind build.
+- **No Docker, no CI.** `make run` and a Procfile.
+
+MIT licensed. Fork it, rename it, ship it, sell it — no attribution required.
 
 ## Tech stack
 
@@ -65,7 +96,7 @@ Visit **http://localhost:8000** — admin login: `admin@example.com` / `admin123
 | `make install` | Create virtualenv and install dependencies |
 | `make run` | Start development server |
 | `make migrate` | Run makemigrations + migrate |
-| `make test` | Run 16 tests |
+| `make test` | Run 29 tests |
 | `make seed` | Populate demo data (admin + plans) |
 | `make lint` | Lint with ruff |
 | `make format` | Format with ruff |
@@ -94,13 +125,14 @@ django-saas-boilerplate/
 │   │   └── management/commands/seed_data.py
 │   ├── subscriptions/        # Stripe integration
 │   │   ├── models.py         # StripeCustomer
-│   │   └── views.py          # checkout, webhooks
+│   │   ├── views.py          # checkout, webhooks
+│   │   └── tests.py          # 10 tests
 │   └── landing/              # Public pages
 │       ├── views.py          # home, features, pricing, robots.txt
 │       └── tests.py          # 4 tests
 ├── templates/
 │   ├── base.html             # Public layout (nav + footer)
-│   ├── account/              # 20 allauth templates (styled)
+│   ├── account/              # 21 allauth templates (styled)
 │   ├── dashboard/            # Dashboard layout + pages
 │   ├── landing/              # Home, features, pricing
 │   └── subscriptions/        # Stripe checkout
@@ -141,7 +173,7 @@ STRIPE_PRICE_ID=price_...
 
 ## Django 6.0 features used
 
-This boilerplate uses three major features introduced in Django 6.0:
+This boilerplate uses two features introduced in Django 6.0:
 
 **Background Tasks** — Send emails asynchronously without Celery:
 ```python
@@ -164,17 +196,6 @@ SECURE_CSP = {
 ```
 ```html
 <script nonce="{{ csp_nonce }}" src="..."></script>
-```
-
-**Template Partials** — Reusable template components without separate files:
-```html
-{% partialdef stat_card inline %}
-<div class="card">{{ card_title }}: {{ card_value }}</div>
-{% endpartialdef %}
-
-{% with card_title="Users" card_value="42" %}
-    {% partial stat_card %}
-{% endwith %}
 ```
 
 ## Deployment
@@ -203,20 +224,28 @@ python manage.py collectstatic
 gunicorn core.wsgi --bind 0.0.0.0:8000
 ```
 
-## Premium version
+## If you need the other half
 
-Looking for more? **[DjangoBlaze](https://www.djangoblaze.com)** is the premium version with:
+Some of what is missing above is a weekend of work. Some of it is not — plan
+gating, dunning and GDPR flows are the parts that quietly eat a month.
 
-- Teams & multi-tenancy (roles, invitations, team-scoped data)
-- AI chat with OpenAI streaming
-- Blog with markdown, SEO, and sitemaps
-- Google OAuth
-- Onboarding wizard
-- Admin metrics dashboard (MRR, signups chart)
-- 20 slash commands for Claude Code
-- 15 AI-friendly documentation guides
-- 30 ready-to-use prompts
-- 48 passing tests
+[**DjangoBlaze**](https://djangoblaze.com) is the paid version of this
+boilerplate, and it is where that work already lives:
+
+- Teams and multi-tenancy
+- Per-plan feature gating with usage limits
+- REST API with hashed keys
+- AI chat
+- Blog with SEO
+- Two-factor authentication
+- Dunning (failed-payment recovery)
+- GDPR account deletion and data export
+- Docker, CI
+- 24 AI skills for working on the codebase
+
+8 apps, 203 tests. $99 one time, unlimited projects, one year of updates.
+
+No pressure either way — this repo is MIT and stays that way.
 
 ## Contributing
 

--- a/apps/dashboard/management/commands/seed_data.py
+++ b/apps/dashboard/management/commands/seed_data.py
@@ -1,5 +1,9 @@
+import os
+import secrets
+
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from apps.dashboard.models import SubscriptionPlan
 
@@ -7,18 +11,42 @@ User = get_user_model()
 
 
 class Command(BaseCommand):
-    help = 'Seed the database with initial data (admin user + subscription plans)'
+    help = 'Seed the database with initial data. Development only.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--admin-email',
+            default=os.getenv('SEED_ADMIN_EMAIL', 'admin@example.com'),
+            help='Email for the seeded superuser.',
+        )
 
     def handle(self, *args, **options):
+        # This creates a superuser. The command is documented in the README, so
+        # it is easy to point at the wrong database; in a public repository any
+        # fixed credential here is a published one, scannable across every
+        # deployment that ran it.
+        if not settings.DEBUG and os.getenv('ALLOW_SEED') != '1':
+            raise CommandError(
+                'seed_data creates a superuser and will not run with DEBUG=False. '
+                'Set ALLOW_SEED=1 to override if you are certain this is not a '
+                'production database.'
+            )
+
+        admin_email = options['admin_email']
+
         # Create admin user
         user, created = User.objects.get_or_create(
-            email='admin@example.com',
+            email=admin_email,
             defaults={'is_staff': True, 'is_superuser': True, 'first_name': 'Admin'},
         )
         if created:
-            user.set_password('admin123')
+            # Generated, never a literal: a password committed to a public repo
+            # is a password everyone already has.
+            password = os.getenv('SEED_ADMIN_PASSWORD') or secrets.token_urlsafe(16)
+            user.set_password(password)
             user.save()
-            self.stdout.write(self.style.SUCCESS('Admin user created (admin@example.com / admin123)'))
+            self.stdout.write(self.style.SUCCESS(f'Admin user created: {admin_email}'))
+            self.stdout.write(self.style.WARNING(f'Password (shown once): {password}'))
         else:
             self.stdout.write('Admin user already exists')
 

--- a/apps/dashboard/views.py
+++ b/apps/dashboard/views.py
@@ -1,11 +1,20 @@
 import hashlib
+import logging
 import secrets
 
+import stripe
+
+# Aliased: this module defines a view called `settings`, which would shadow
+# the import and turn settings.STRIPE_SECRET_KEY into an attribute lookup
+# on a function.
+from django.conf import settings as django_settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
+
+from apps.subscriptions.models import StripeCustomer
 
 from .models import SubscriptionPlan, UserSettings
 from .tasks import (
@@ -13,6 +22,8 @@ from .tasks import (
     send_subscription_confirmation_email,
     send_trial_started_email,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @login_required
@@ -26,8 +37,16 @@ def profile(request):
     if request.method == 'POST':
         # Handle profile update
         user = request.user
-        user.first_name = request.POST.get('first_name', '')
-        user.last_name = request.POST.get('last_name', '')
+        # max_length=150 on both. PostgreSQL raises DataError past that (a
+        # 500) while SQLite truncates in silence, so this only ever breaks
+        # once it is deployed.
+        first_name = request.POST.get('first_name', '').strip()
+        last_name = request.POST.get('last_name', '').strip()
+        if len(first_name) > 150 or len(last_name) > 150:
+            messages.error(request, 'Names must be 150 characters or fewer.')
+            return redirect('dashboard:profile')
+        user.first_name = first_name
+        user.last_name = last_name
         user.save()
         messages.success(request, 'Profile updated successfully.')
         return redirect('dashboard:profile')
@@ -110,8 +129,23 @@ def subscription_plans(request):
 @login_required
 @require_http_methods(['POST'])
 def subscribe_to_plan(request, plan_slug):
+    """Activate a FREE plan.
+
+    This view grants the plan directly, with no payment step, so it must never
+    be reachable for a plan that costs money: a plain POST to this URL would
+    otherwise hand any signed-in user a paid tier for nothing. Paid plans go
+    through the Stripe checkout in apps/subscriptions/, which is the only place
+    a charge actually happens.
+    """
     plan = get_object_or_404(SubscriptionPlan, slug=plan_slug, is_active=True)
     user_settings = UserSettings.objects.get(user=request.user)
+
+    if plan.price and plan.price > 0:
+        messages.error(
+            request,
+            'That plan has to be paid for. Continue to checkout to subscribe.',
+        )
+        return redirect('subscriptions:subscription_page')
 
     # Check if user already has an active subscription
     if user_settings.is_subscription_active:
@@ -142,7 +176,40 @@ def subscribe_to_plan(request, plan_slug):
 @login_required
 @require_http_methods(['POST'])
 def cancel_subscription(request):
-    user_settings = UserSettings.objects.get(user=request.user)
+    """Cancel at Stripe, not just locally.
+
+    This used to flip a local flag and nothing else, so Stripe went on charging
+    the card every month for a subscription the customer had cancelled and
+    could no longer see. It also revoked access instantly, taking away time the
+    customer had already paid for; cancelling at period end keeps both sides
+    honest.
+    """
+    user_settings, _ = UserSettings.objects.get_or_create(user=request.user)
+
+    stripe_customer = StripeCustomer.objects.filter(user=request.user).first()
+    if stripe_customer and stripe_customer.stripe_subscription_id:
+        try:
+            stripe.api_key = django_settings.STRIPE_SECRET_KEY
+            stripe.Subscription.modify(
+                stripe_customer.stripe_subscription_id, cancel_at_period_end=True
+            )
+        except stripe.StripeError:
+            logger.exception('Could not cancel subscription for user %s', request.user.pk)
+            messages.error(
+                request,
+                'We could not reach the payment provider. Your subscription was not '
+                'cancelled — please try again or contact support.',
+            )
+            return redirect('dashboard:settings')
+
+        # Paid time already bought stays theirs until the period ends.
+        messages.success(
+            request,
+            'Your subscription will not renew. You keep access until the end of '
+            'the current billing period.',
+        )
+        return redirect('dashboard:settings')
+
 
     if not user_settings.is_subscription_active:
         messages.warning(request, 'You do not have an active subscription to cancel.')
@@ -163,6 +230,13 @@ def start_trial(request):
 
     if user_settings.is_subscription_active or user_settings.is_trial_active:
         messages.warning(request, 'You already have an active subscription or trial.')
+        return redirect('dashboard:subscription_plans')
+
+    # trial_end_date outlives the trial itself, so an expired one still proves
+    # the user already had theirs. Without this check the guard above passes
+    # again the moment it lapses and the trial is repeatable for ever.
+    if user_settings.trial_end_date:
+        messages.warning(request, 'Your free trial has already been used.')
         return redirect('dashboard:subscription_plans')
 
     # Start trial period (14 days)

--- a/apps/subscriptions/models.py
+++ b/apps/subscriptions/models.py
@@ -7,6 +7,11 @@ class StripeCustomer(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     stripe_customer_id = models.CharField(max_length=255)
     stripe_subscription_id = models.CharField(max_length=255, blank=True, default='')
+    # This says whether they pay, not what they are allowed to do. The moment
+    # you need per-plan feature gating or usage limits, that logic starts here
+    # and it is more work than it looks (entitlements separate from marketing
+    # copy, quota counters, grace periods, an answer for API callers).
+    # DjangoBlaze ships it: https://djangoblaze.com
     subscription_status = models.CharField(max_length=50, blank=True, default='')
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/apps/subscriptions/tests.py
+++ b/apps/subscriptions/tests.py
@@ -1,0 +1,139 @@
+import json
+from unittest.mock import patch
+
+import stripe
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from django.urls import reverse
+
+from .models import StripeCustomer
+
+User = get_user_model()
+
+
+@override_settings(STRIPE_PRICE_ID='price_123', STRIPE_WEBHOOK_SECRET='whsec_x')
+class CheckoutSmokeTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email='a@example.com', password='pw12345678')
+        self.client.force_login(self.user)
+
+    @patch('apps.subscriptions.views.stripe.Subscription.create')
+    @patch('apps.subscriptions.views.stripe.Customer.modify')
+    @patch('apps.subscriptions.views.stripe.PaymentMethod.attach')
+    @patch('apps.subscriptions.views.stripe.Customer.create')
+    def test_returns_confirmation_secret(self, cust_create, pm_attach, cust_mod, sub_create):
+        cust_create.return_value = stripe.Customer.construct_from({'id': 'cus_1'}, 'k')
+        sub_create.return_value = stripe.Subscription.construct_from({
+            'id': 'sub_1',
+            'status': 'incomplete',
+            'latest_invoice': {
+                'id': 'in_1',
+                'confirmation_secret': {'client_secret': 'pi_1_secret_abc', 'type': 'payment_intent'},
+            },
+        }, 'k')
+
+        resp = self.client.post(
+            reverse('subscriptions:create_subscription'),
+            data=json.dumps({'payment_method_id': 'pm_1'}),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body['client_secret'], 'pi_1_secret_abc')
+        self.assertTrue(body['requires_confirmation'])
+        self.assertEqual(body['status'], 'incomplete')
+
+        kwargs = sub_create.call_args.kwargs
+        self.assertEqual(kwargs['expand'], ['latest_invoice.confirmation_secret'])
+        self.assertIn('idempotency_key', kwargs)
+
+        sc = StripeCustomer.objects.get(user=self.user)
+        self.assertEqual(sc.stripe_subscription_id, 'sub_1')
+
+    @patch('apps.subscriptions.views.stripe.Customer.create')
+    def test_card_error_is_402(self, cust_create):
+        cust_create.side_effect = stripe.CardError('declined', None, 'card_declined')
+        resp = self.client.post(
+            reverse('subscriptions:create_subscription'),
+            data=json.dumps({'payment_method_id': 'pm_1'}),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 402)
+        self.assertIn('error', resp.json())
+
+    @patch('apps.subscriptions.views.stripe.Customer.create')
+    def test_stripe_error_is_502(self, cust_create):
+        cust_create.side_effect = stripe.APIConnectionError('boom')
+        resp = self.client.post(
+            reverse('subscriptions:create_subscription'),
+            data=json.dumps({'payment_method_id': 'pm_1'}),
+            content_type='application/json',
+        )
+        self.assertEqual(resp.status_code, 502)
+
+    def test_bad_signature_returns_400_not_500(self):
+        resp = self.client.post(
+            reverse('subscriptions:stripe_webhook'),
+            data='{}',
+            content_type='application/json',
+            HTTP_STRIPE_SIGNATURE='t=1,v1=bogus',
+        )
+        self.assertEqual(resp.status_code, 400)
+
+    @patch('apps.subscriptions.views.stripe.Webhook.construct_event')
+    def test_webhook_updates_status(self, construct):
+        StripeCustomer.objects.create(
+            user=self.user, stripe_customer_id='cus_1', stripe_subscription_id='sub_1'
+        )
+        construct.return_value = {
+            'id': 'evt_1',
+            'type': 'customer.subscription.updated',
+            'data': {'object': {'id': 'sub_1', 'status': 'active'}},
+        }
+        resp = self.client.post(
+            reverse('subscriptions:stripe_webhook'),
+            data='{}', content_type='application/json', HTTP_STRIPE_SIGNATURE='sig',
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(StripeCustomer.objects.get(user=self.user).subscription_status, 'active')
+
+    @patch('apps.subscriptions.views.stripe.Webhook.construct_event')
+    def test_webhook_unknown_subscription_is_200(self, construct):
+        construct.return_value = {
+            'id': 'evt_2',
+            'type': 'customer.subscription.updated',
+            'data': {'object': {'id': 'sub_unknown', 'status': 'active'}},
+        }
+        resp = self.client.post(
+            reverse('subscriptions:stripe_webhook'),
+            data='{}', content_type='application/json', HTTP_STRIPE_SIGNATURE='sig',
+        )
+        self.assertEqual(resp.status_code, 200)
+
+    def test_subscription_page_without_customer(self):
+        resp = self.client.get(reverse('subscriptions:subscription_page'))
+        self.assertEqual(resp.status_code, 200)
+
+    def test_subscription_page_with_blank_subscription_id(self):
+        StripeCustomer.objects.create(user=self.user, stripe_customer_id='cus_1')
+        resp = self.client.get(reverse('subscriptions:subscription_page'))
+        self.assertEqual(resp.status_code, 200)
+
+
+class CurrentPeriodEndTest(TestCase):
+    def test_reads_the_date_off_the_subscription_item(self):
+        from apps.subscriptions.views import _current_period_end
+
+        sub = stripe.Subscription.construct_from({
+            'id': 'sub_1',
+            'status': 'active',
+            'items': {'object': 'list', 'data': [{'id': 'si_1', 'current_period_end': 1767225600}]},
+        }, 'k')
+        self.assertEqual(_current_period_end(sub).year, 2026)
+
+    def test_missing_period_is_none_not_an_error(self):
+        from apps.subscriptions.views import _current_period_end
+
+        self.assertIsNone(_current_period_end(None))
+        sub = stripe.Subscription.construct_from({'id': 'sub_1', 'status': 'active'}, 'k')
+        self.assertIsNone(_current_period_end(sub))

--- a/apps/subscriptions/tests.py
+++ b/apps/subscriptions/tests.py
@@ -182,3 +182,181 @@ class SettingsHardeningTest(TestCase):
 
         # Verification links printed to a production log reach nobody.
         self.assertIn("if DEBUG", settings_src.split("EMAIL_BACKEND = os.getenv(")[1][:200])
+
+
+class PaidPlanCannotBeSelfGrantedTest(TestCase):
+    """subscribe_to_plan activates a plan with no payment step, so a POST to it
+    used to hand any signed-in user a paid tier for free. In a boilerplate whose
+    whole point is billing, that is the most expensive bug it can have."""
+
+    def setUp(self):
+        from apps.dashboard.models import SubscriptionPlan, UserSettings
+
+        self.user = User.objects.create_user(email="freeloader@example.com", password="testpass123")
+        UserSettings.objects.get_or_create(user=self.user)
+        self.client.force_login(self.user)
+        self.paid = SubscriptionPlan.objects.create(
+            name="Enterprise", slug="enterprise", price=49.99, interval="monthly", is_active=True
+        )
+        self.free = SubscriptionPlan.objects.create(
+            name="Free", slug="free", price=0, interval="monthly", is_active=True
+        )
+
+    def _subscribe(self, slug):
+        return self.client.post(f"/dashboard/subscription/plans/{slug}/subscribe/")
+
+    def _settings(self):
+        from apps.dashboard.models import UserSettings
+
+        return UserSettings.objects.get(user=self.user)
+
+    def test_a_paid_plan_cannot_be_granted_without_paying(self):
+        self._subscribe("enterprise")
+
+        settings_row = self._settings()
+        self.assertNotEqual(settings_row.subscription_status, "active")
+        self.assertIsNone(settings_row.subscription_plan)
+
+    def test_a_free_plan_still_activates(self):
+        self._subscribe("free")
+
+        settings_row = self._settings()
+        self.assertEqual(settings_row.subscription_status, "active")
+        self.assertEqual(settings_row.subscription_plan, self.free)
+
+    def test_the_free_trial_cannot_be_restarted_once_used(self):
+        from django.utils import timezone
+
+        # An expired trial leaves trial_end_date behind but makes both the
+        # active checks False, which is how it used to become repeatable.
+        row = self._settings()
+        row.trial_end_date = timezone.now() - timezone.timedelta(days=1)
+        row.save()
+
+        self.client.post("/dashboard/subscription/trial/")
+
+        row.refresh_from_db()
+        self.assertLess(row.trial_end_date, timezone.now())
+
+
+class SeedDataGuardTest(TestCase):
+    """The README documents this command, including in its deployment section,
+    so it must not be able to fire against a production database."""
+
+    def test_it_refuses_to_run_with_debug_off(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        with override_settings(DEBUG=False):
+            with self.assertRaises(CommandError):
+                call_command("seed_data", stdout=StringIO())
+
+    def test_no_password_literal_survives_in_the_command(self):
+        import pathlib
+
+        src = (
+            pathlib.Path(__file__).resolve().parents[2]
+            / "apps" / "dashboard" / "management" / "commands" / "seed_data.py"
+        ).read_text()
+
+        self.assertNotIn("admin123", src)
+
+
+class PaidAccessIsGrantedTest(TestCase):
+    """Two subscription records live side by side: StripeCustomer, written by
+    the payment flow, and UserSettings, read by every permission check. Nothing
+    connected them, so a customer could pay, have Stripe report the
+    subscription active, and still be locked out of what they just bought."""
+
+    def setUp(self):
+        from apps.dashboard.models import UserSettings
+
+        self.user = User.objects.create_user(email="payer@example.com", password="testpass123")
+        UserSettings.objects.get_or_create(user=self.user)
+
+    def _settings(self):
+        from apps.dashboard.models import UserSettings
+
+        return UserSettings.objects.get(user=self.user)
+
+    def test_an_active_stripe_status_grants_access(self):
+        from .views import _sync_access
+
+        _sync_access(self.user, "active")
+
+        self.assertTrue(self._settings().is_subscription_active)
+
+    def test_a_trialing_status_grants_trial_access(self):
+        from .views import _sync_access
+
+        _sync_access(self.user, "trialing")
+
+        self.assertTrue(self._settings().is_trial_active)
+
+    def test_past_due_keeps_access_while_stripe_retries(self):
+        from .views import _sync_access
+
+        _sync_access(self.user, "past_due")
+
+        self.assertTrue(self._settings().is_subscription_active)
+
+    def test_an_incomplete_payment_grants_nothing(self):
+        from .views import _sync_access
+
+        _sync_access(self.user, "incomplete")
+
+        self.assertFalse(self._settings().is_subscription_active)
+
+    def test_a_cancelled_subscription_revokes_access(self):
+        from .views import _sync_access
+
+        _sync_access(self.user, "active")
+        _sync_access(self.user, "canceled")
+
+        self.assertFalse(self._settings().is_subscription_active)
+
+    def test_an_unknown_status_denies_rather_than_grants(self):
+        from .views import _sync_access
+
+        _sync_access(self.user, "something_stripe_added_last_week")
+
+        self.assertFalse(self._settings().is_subscription_active)
+
+
+class CancelReachesStripeTest(TestCase):
+    """Cancelling used to flip a local flag and nothing else, so Stripe kept
+    charging the card every month for a subscription the customer believed they
+    had cancelled."""
+
+    def setUp(self):
+        from apps.dashboard.models import UserSettings
+
+        self.user = User.objects.create_user(email="quitter@example.com", password="testpass123")
+        UserSettings.objects.get_or_create(user=self.user)
+        StripeCustomer.objects.create(
+            user=self.user, stripe_customer_id="cus_1", stripe_subscription_id="sub_1"
+        )
+        self.client.force_login(self.user)
+
+    @patch("apps.dashboard.views.stripe")
+    def test_it_cancels_at_stripe(self, mock_stripe):
+        mock_stripe.StripeError = Exception
+
+        self.client.post("/dashboard/subscription/cancel/")
+
+        mock_stripe.Subscription.modify.assert_called_once_with(
+            "sub_1", cancel_at_period_end=True
+        )
+
+    @patch("apps.dashboard.views.stripe")
+    def test_a_stripe_failure_does_not_pretend_it_cancelled(self, mock_stripe):
+        # Telling someone their subscription is cancelled when it is not is how
+        # a chargeback starts.
+        mock_stripe.StripeError = Exception
+        mock_stripe.Subscription.modify.side_effect = Exception("network")
+
+        response = self.client.post("/dashboard/subscription/cancel/", follow=True)
+
+        self.assertContains(response, "was not")

--- a/apps/subscriptions/tests.py
+++ b/apps/subscriptions/tests.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import stripe
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -137,3 +138,47 @@ class CurrentPeriodEndTest(TestCase):
         self.assertIsNone(_current_period_end(None))
         sub = stripe.Subscription.construct_from({'id': 'sub_1', 'status': 'active'}, 'k')
         self.assertIsNone(_current_period_end(sub))
+
+
+class SettingsHardeningTest(TestCase):
+    """This repository is public, so a committed default is a published value.
+
+    These pin the failure direction: a deployment that forgets a variable must
+    stop, not quietly run with something everyone can read.
+    """
+
+    def test_no_hardcoded_secret_key_fallback(self):
+        import pathlib
+        import re
+
+        settings_src = (pathlib.Path(__file__).resolve().parents[2] / "core" / "settings.py").read_text()
+        assignment = re.search(r"^SECRET_KEY = .*$", settings_src, re.M).group(0)
+
+        # A fallback here ships a key that anyone can read off GitHub and use to
+        # forge session cookies on every deployment that forgot the variable.
+        self.assertNotIn("django-insecure-default", assignment)
+        self.assertEqual(assignment, "SECRET_KEY = os.getenv('SECRET_KEY')")
+
+    def test_debug_fails_closed(self):
+        import pathlib
+        import re
+
+        settings_src = (pathlib.Path(__file__).resolve().parents[2] / "core" / "settings.py").read_text()
+        assignment = re.search(r"^DEBUG = os\.getenv.*$", settings_src, re.M).group(0)
+
+        self.assertIn("'DEBUG', 'False'", assignment)
+
+    def test_the_proxy_header_is_set(self):
+        # Without it, SECURE_SSL_REDIRECT loops forever behind a PaaS edge and
+        # HSTS is never emitted.
+        self.assertEqual(
+            settings.SECURE_PROXY_SSL_HEADER, ("HTTP_X_FORWARDED_PROTO", "https")
+        )
+
+    def test_email_does_not_default_to_console_in_production(self):
+        import pathlib
+
+        settings_src = (pathlib.Path(__file__).resolve().parents[2] / "core" / "settings.py").read_text()
+
+        # Verification links printed to a production log reach nobody.
+        self.assertIn("if DEBUG", settings_src.split("EMAIL_BACKEND = os.getenv(")[1][:200])

--- a/apps/subscriptions/views.py
+++ b/apps/subscriptions/views.py
@@ -1,69 +1,149 @@
+import json
+import logging
+from datetime import datetime
+from datetime import timezone as dt_timezone
+
 import stripe
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
-from django.shortcuts import redirect, render
+from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 from .models import StripeCustomer
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
+# Pinned on purpose rather than inherited from the installed SDK.
+# See STRIPE_API_VERSION in core/settings.py.
+stripe.api_version = settings.STRIPE_API_VERSION
+
+logger = logging.getLogger(__name__)
 
 @login_required
 def subscription_page(request):
-    try:
-        # Get or create Stripe customer
-        stripe_customer = StripeCustomer.objects.get(user=request.user)
-        subscription = stripe.Subscription.retrieve(stripe_customer.stripe_subscription_id)
-        return render(request, 'subscriptions/subscription.html', {
-            'subscription': subscription,
-            'STRIPE_PUBLIC_KEY': settings.STRIPE_PUBLIC_KEY
-        })
-    except StripeCustomer.DoesNotExist:
-        return render(request, 'subscriptions/subscription.html', {
-            'STRIPE_PUBLIC_KEY': settings.STRIPE_PUBLIC_KEY
-        })
+    subscription = None
+    stripe_customer = StripeCustomer.objects.filter(user=request.user).first()
+
+    if stripe_customer and stripe_customer.stripe_subscription_id:
+        try:
+            subscription = stripe.Subscription.retrieve(stripe_customer.stripe_subscription_id)
+        except stripe.StripeError:
+            # A subscription id Stripe no longer knows about (deleted in the
+            # dashboard, or created with test keys) must not 500 the page.
+            logger.exception('Could not load subscription for user %s', request.user.pk)
+            subscription = None
+
+    return render(request, 'subscriptions/subscription.html', {
+        'subscription': subscription,
+        'current_period_end': _current_period_end(subscription),
+        'STRIPE_PUBLIC_KEY': settings.STRIPE_PUBLIC_KEY,
+    })
+
+
+def _current_period_end(subscription):
+    """Renewal date of a subscription, as a datetime.
+
+    Two things make this less obvious than it looks. The period moved off the
+    subscription onto each subscription item, and Stripe sends it as a Unix
+    timestamp, which Django's `date` filter renders as an empty string.
+    """
+    if subscription is None:
+        return None
+
+    items = getattr(subscription, 'items', None)
+    data = getattr(items, 'data', None) or []
+    timestamp = getattr(data[0], 'current_period_end', None) if data else None
+    if timestamp is None:
+        return None
+
+    return datetime.fromtimestamp(timestamp, tz=dt_timezone.utc)
 
 @login_required
+@require_POST
 def create_subscription(request):
-    if request.method == 'POST':
-        # Create or get Stripe customer
-        try:
-            stripe_customer = StripeCustomer.objects.get(user=request.user)
-            customer = stripe_customer.stripe_customer_id
-        except StripeCustomer.DoesNotExist:
-            customer = stripe.Customer.create(
-                email=request.user.email,
-                source=request.POST['stripeToken']
-            )
-            stripe_customer = StripeCustomer.objects.create(
+    try:
+        data = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse({'error': 'Invalid request'}, status=400)
+
+    payment_method_id = data.get('payment_method_id')
+    if not payment_method_id:
+        return JsonResponse({'error': 'Payment method is required'}, status=400)
+
+    if not settings.STRIPE_PRICE_ID:
+        return JsonResponse({'error': 'No Stripe price configured'}, status=400)
+
+    try:
+        stripe_customer = StripeCustomer.objects.filter(user=request.user).first()
+        if stripe_customer and stripe_customer.stripe_customer_id:
+            customer_id = stripe_customer.stripe_customer_id
+        else:
+            customer = stripe.Customer.create(email=request.user.email)
+            customer_id = customer.id
+            stripe_customer, _ = StripeCustomer.objects.update_or_create(
                 user=request.user,
-                stripe_customer_id=customer.id
+                defaults={'stripe_customer_id': customer_id},
             )
 
-        # Create subscription
-        subscription = stripe.Subscription.create(
-            customer=customer,
-            items=[{'price': settings.STRIPE_PRICE_ID}],
-            payment_behavior='default_incomplete',
-            expand=['latest_invoice.payment_intent'],
+        # The card reaches Stripe as a PaymentMethod (created in the browser by
+        # stripe.js), never as a legacy token, and it has to be attached to the
+        # customer before the subscription can charge it.
+        stripe.PaymentMethod.attach(payment_method_id, customer=customer_id)
+        stripe.Customer.modify(
+            customer_id,
+            invoice_settings={'default_payment_method': payment_method_id},
         )
 
-        stripe_customer.stripe_subscription_id = subscription.id
-        stripe_customer.subscription_status = subscription.status
-        stripe_customer.save()
+        subscription = stripe.Subscription.create(
+            customer=customer_id,
+            items=[{'price': settings.STRIPE_PRICE_ID}],
+            payment_behavior='default_incomplete',
+            # `latest_invoice.payment_intent` was removed from the API. The
+            # secret the browser confirms with now lives on the invoice's
+            # confirmation_secret.
+            expand=['latest_invoice.confirmation_secret'],
+            # A double-clicked button must not create two paid subscriptions:
+            # Stripe replays the first result instead.
+            idempotency_key=f'sub:{request.user.pk}:{settings.STRIPE_PRICE_ID}:{payment_method_id}',
+        )
+    except stripe.CardError as exc:
+        return JsonResponse({'error': exc.user_message or 'Your card was declined.'}, status=402)
+    except stripe.StripeError:
+        logger.exception('Stripe rejected the subscription for user %s', request.user.pk)
+        return JsonResponse(
+            {'error': 'We could not start your subscription. Please try again.'},
+            status=502,
+        )
 
-        return JsonResponse({
-            'subscription_id': subscription.id,
-            'client_secret': subscription.latest_invoice.payment_intent.client_secret,
-        })
+    stripe_customer.stripe_subscription_id = subscription.id
+    stripe_customer.subscription_status = subscription.status
+    stripe_customer.save()
 
-    return redirect('subscription_page')
+    # Attribute access, not .get(): a Stripe resource object is not a dict.
+    # If the expand above ever stops resolving, latest_invoice comes back as a
+    # bare id string and these fall through to None instead of raising.
+    invoice = getattr(subscription, 'latest_invoice', None)
+    confirmation_secret = getattr(invoice, 'confirmation_secret', None)
+    client_secret = getattr(confirmation_secret, 'client_secret', None)
+
+    return JsonResponse({
+        'subscription_id': subscription.id,
+        'client_secret': client_secret,
+        # A trial or a 100% coupon leaves nothing for the browser to confirm.
+        'requires_confirmation': bool(client_secret),
+        'status': subscription.status,
+    })
 
 @csrf_exempt
 @require_POST
 def stripe_webhook(request):
+    if not settings.STRIPE_WEBHOOK_SECRET:
+        # Without a secret nothing is verifiable, so anyone could post a fake
+        # "subscription active". Refuse rather than trust the payload.
+        logger.error('STRIPE_WEBHOOK_SECRET is not set; refusing to process webhooks')
+        return HttpResponse(status=500)
+
     payload = request.body
     sig_header = request.META.get('HTTP_STRIPE_SIGNATURE')
 
@@ -73,13 +153,20 @@ def stripe_webhook(request):
         )
     except ValueError:
         return HttpResponse(status=400)
-    except stripe.error.SignatureVerificationError:
+    except stripe.SignatureVerificationError:
         return HttpResponse(status=400)
 
-    if event['type'] == 'customer.subscription.updated':
+    if event['type'] in ('customer.subscription.updated', 'customer.subscription.deleted'):
         subscription = event['data']['object']
-        stripe_customer = StripeCustomer.objects.get(stripe_subscription_id=subscription.id)
-        stripe_customer.subscription_status = subscription.status
+        stripe_customer = StripeCustomer.objects.filter(
+            stripe_subscription_id=subscription['id']
+        ).first()
+        if stripe_customer is None:
+            # Unknown subscription. Acknowledge it, or Stripe retries forever.
+            logger.warning('Webhook: no StripeCustomer for subscription %s', subscription['id'])
+            return HttpResponse(status=200)
+
+        stripe_customer.subscription_status = subscription['status']
         stripe_customer.save()
 
     return HttpResponse(status=200)

--- a/apps/subscriptions/views.py
+++ b/apps/subscriptions/views.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
+from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
@@ -19,6 +20,40 @@ stripe.api_key = settings.STRIPE_SECRET_KEY
 stripe.api_version = settings.STRIPE_API_VERSION
 
 logger = logging.getLogger(__name__)
+
+# Stripe's own subscription statuses, mapped onto the four this project gates
+# on. Anything not listed leaves the user without access.
+STATUS_MAP = {
+    'active': 'active',
+    'trialing': 'trial',
+    'past_due': 'active',      # keep serving while Stripe retries the charge
+    'canceled': 'cancelled',
+    'unpaid': 'inactive',
+    'incomplete': 'inactive',
+    'incomplete_expired': 'inactive',
+    'paused': 'inactive',
+}
+
+
+def _sync_access(user, stripe_status, period_end=None):
+    """Mirror a Stripe status onto the record the app actually gates on.
+
+    Two subscription records exist side by side: StripeCustomer, written by this
+    app, and UserSettings, read by every permission check in the dashboard.
+    Nothing connected them, so a customer could pay, have Stripe report the
+    subscription as active, and still be denied access to everything they had
+    just bought. This is that connection.
+    """
+    from apps.dashboard.models import UserSettings
+
+    settings_row, _ = UserSettings.objects.get_or_create(user=user)
+    settings_row.subscription_status = STATUS_MAP.get(stripe_status, 'inactive')
+    if period_end is not None:
+        settings_row.subscription_end_date = period_end
+    if settings_row.subscription_status == 'active' and not settings_row.subscription_start_date:
+        settings_row.subscription_start_date = timezone.now()
+    settings_row.save()
+    return settings_row
 
 @login_required
 def subscription_page(request):
@@ -120,6 +155,10 @@ def create_subscription(request):
     stripe_customer.subscription_status = subscription.status
     stripe_customer.save()
 
+    # Without this the buyer is charged and still locked out: every gate in the
+    # dashboard reads UserSettings, not this row.
+    _sync_access(request.user, subscription.status, _current_period_end(subscription))
+
     # Attribute access, not .get(): a Stripe resource object is not a dict.
     # If the expand above ever stops resolving, latest_invoice comes back as a
     # bare id string and these fall through to None instead of raising.
@@ -168,5 +207,6 @@ def stripe_webhook(request):
 
         stripe_customer.subscription_status = subscription['status']
         stripe_customer.save()
+        _sync_access(stripe_customer.user, subscription['status'])
 
     return HttpResponse(status=200)

--- a/core/settings.py
+++ b/core/settings.py
@@ -188,6 +188,12 @@ STRIPE_PUBLIC_KEY = os.getenv('STRIPE_PUBLIC_KEY', '')
 STRIPE_SECRET_KEY = os.getenv('STRIPE_SECRET_KEY', '')
 STRIPE_WEBHOOK_SECRET = os.getenv('STRIPE_WEBHOOK_SECRET', '')
 STRIPE_PRICE_ID = os.getenv('STRIPE_PRICE_ID', '')
+# Pin the Stripe API version instead of inheriting whatever the installed SDK
+# defaults to. Stripe reshapes objects between versions -- `invoice.payment_intent`
+# no longer exists, the client secret moved to `invoice.confirmation_secret` --
+# so leaving this unset means a routine `pip install -U stripe` can change the
+# response shape and break checkout in production without a code change.
+STRIPE_API_VERSION = os.getenv('STRIPE_API_VERSION', '2026-08-26.dahlia')
 
 # Content Security Policy (Django 6.0)
 # https://docs.djangoproject.com/en/6.0/ref/middleware/#content-security-policy

--- a/core/settings.py
+++ b/core/settings.py
@@ -28,12 +28,34 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv('SECRET_KEY', 'django-insecure-default-key-change-me')
+# SECURITY WARNING: keep the secret key used in production secret!
+# There is no hardcoded fallback on purpose. This repository is public, so any
+# default committed here is a published key: whoever deploys without setting
+# the variable would be running with a key that anyone can read, and with it
+# forge session cookies and password-reset tokens.
+SECRET_KEY = os.getenv('SECRET_KEY')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv('DEBUG', 'True').lower() == 'true'
+# Defaults to False so a missing or misspelled variable fails closed.
+# Development opts in explicitly through .env (see .env.example).
+DEBUG = os.getenv('DEBUG', 'False').lower() == 'true'
 
-ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
+if not SECRET_KEY:
+    if DEBUG:
+        # Development only, and only because DEBUG was explicitly turned on.
+        SECRET_KEY = 'django-insecure-dev-only-key-do-not-use-in-production'
+    else:
+        from django.core.exceptions import ImproperlyConfigured
+
+        raise ImproperlyConfigured(
+            'SECRET_KEY environment variable is required when DEBUG is off.'
+        )
+
+ALLOWED_HOSTS = [
+    host.strip()
+    for host in os.getenv('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
+    if host.strip()
+]
 
 
 # Application definition
@@ -108,6 +130,10 @@ DATABASES = {
     'default': dj_database_url.config(
         default=f'sqlite:///{BASE_DIR / "db.sqlite3"}',
         conn_max_age=600,
+        # Without this, a connection the database closed on its own (idle
+        # timeout, restart, failover) is handed to the next request and raises
+        # InterfaceError instead of being reopened.
+        conn_health_checks=True,
     )
 }
 
@@ -171,7 +197,15 @@ ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 
 # Email configuration
-EMAIL_BACKEND = os.getenv('EMAIL_BACKEND', 'django.core.mail.backends.console.EmailBackend')
+# The console backend prints emails instead of sending them, which in
+# production means verification links and password resets land in the log
+# stream and no user ever receives them. Only a sane default while DEBUG is on.
+EMAIL_BACKEND = os.getenv(
+    'EMAIL_BACKEND',
+    'django.core.mail.backends.console.EmailBackend'
+    if DEBUG
+    else 'django.core.mail.backends.smtp.EmailBackend',
+)
 EMAIL_HOST = os.getenv('EMAIL_HOST', 'smtp.gmail.com')
 EMAIL_PORT = int(os.getenv('EMAIL_PORT', 587))
 EMAIL_USE_TLS = os.getenv('EMAIL_USE_TLS', 'True').lower() == 'true'
@@ -216,6 +250,13 @@ TASKS = {
 }
 
 # Production security settings
+# Railway, Heroku and Fly terminate TLS at their edge and forward plain HTTP,
+# marking the original scheme in X-Forwarded-Proto. Without this,
+# request.is_secure() is always False, so SECURE_SSL_REDIRECT below redirects
+# to https forever and the HSTS header is never sent. Safe only because those
+# platforms do not let a client reach the app directly.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
 if not DEBUG:
     SECURE_HSTS_SECONDS = 31536000
     SECURE_HSTS_INCLUDE_SUBDOMAINS = True
@@ -223,4 +264,5 @@ if not DEBUG:
     SECURE_SSL_REDIRECT = True
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True
+    SECURE_CONTENT_TYPE_NOSNIFF = True
     X_FRAME_OPTIONS = 'DENY'

--- a/core/settings.py
+++ b/core/settings.py
@@ -57,6 +57,14 @@ ALLOWED_HOSTS = [
     if host.strip()
 ]
 
+# Documented in .env.example but never read, so setting it did nothing and
+# cross-origin POSTs failed behind a domain that was supposedly trusted.
+CSRF_TRUSTED_ORIGINS = [
+    origin.strip()
+    for origin in os.getenv('CSRF_TRUSTED_ORIGINS', 'http://localhost:8000').split(',')
+    if origin.strip()
+]
+
 
 # Application definition
 
@@ -233,12 +241,15 @@ STRIPE_API_VERSION = os.getenv('STRIPE_API_VERSION', '2026-08-26.dahlia')
 # https://docs.djangoproject.com/en/6.0/ref/middleware/#content-security-policy
 SECURE_CSP = {
     "default-src": [CSP.SELF],
-    "script-src": [CSP.SELF, CSP.NONCE, "https://cdn.tailwindcss.com", "https://cdn.jsdelivr.net", "https://unpkg.com"],
+    # js.stripe.com is required for the card element. A nonce never applies to
+    # an inline onclick handler, so anything interactive has to be Alpine or a
+    # real form, never an inline attribute.
+    "script-src": [CSP.SELF, CSP.NONCE, "https://cdn.tailwindcss.com", "https://cdn.jsdelivr.net", "https://js.stripe.com"],
     "style-src": [CSP.SELF, CSP.UNSAFE_INLINE, "https://fonts.googleapis.com", "https://cdnjs.cloudflare.com"],
     "font-src": [CSP.SELF, "https://fonts.gstatic.com", "https://cdnjs.cloudflare.com"],
     "img-src": [CSP.SELF, "https:", "data:"],
     "connect-src": [CSP.SELF, "https://api.stripe.com"],
-    "frame-src": [CSP.SELF, "https://js.stripe.com"],
+    "frame-src": [CSP.SELF, "https://js.stripe.com", "https://hooks.stripe.com"],
 }
 
 # Background Tasks (Django 6.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,21 @@
-Django
-django-allauth
-django-tailwind
-django-htmx
-django-crispy-forms
-crispy-tailwind
-python-dotenv
-whitenoise
-gunicorn
+# Pinned to ranges this codebase is actually tested against. An unpinned list
+# is how the Stripe checkout in this repo broke: the code targeted one API
+# contract and pip installed another, months later, on someone else's machine.
+Django>=6.0,<6.2
+django-allauth>=65.0,<66.0
+django-htmx>=1.29,<2.0
+python-dotenv>=1.0,<2.0
+whitenoise>=6.0,<7.0
+gunicorn>=23.0,<27.0
+dj-database-url>=2.0,<4.0
 stripe>=15.0,<16.0
-dj-database-url
-ruff
+
+# Installed but not wired up: Tailwind is loaded from the CDN in base.html and
+# no form uses crispy. Kept so an existing checkout does not break on upgrade;
+# safe to drop if you are not going to use them.
+django-tailwind>=4.0,<5.0
+django-crispy-forms>=2.0,<3.0
+crispy-tailwind>=1.0,<2.0
+
+# Dev
+ruff>=0.14,<1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ crispy-tailwind
 python-dotenv
 whitenoise
 gunicorn
-stripe
+stripe>=15.0,<16.0
 dj-database-url
 ruff

--- a/templates/base.html
+++ b/templates/base.html
@@ -112,7 +112,7 @@
     {% if messages %}
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-6">
             {% for message in messages %}
-                <div class="border border-light-gray p-4 flex mb-3" role="alert">
+                <div x-data="{ show: true }" x-show="show" class="border border-light-gray p-4 flex mb-3" role="alert">
                     <div class="mr-3">
                         {% if message.tags == 'error' %}
                             <i class="fa-solid fa-circle-exclamation text-black"></i>
@@ -128,7 +128,7 @@
                         <p class="text-sm">{{ message }}</p>
                     </div>
                     <button class="ml-auto pl-3 text-gray hover:text-black"
-                        onclick="this.parentElement.remove()">
+                        @click="show = false">
                         <i class="fa-solid fa-xmark"></i>
                     </button>
                 </div>

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -159,7 +159,7 @@
             <main class="flex-1 px-4 sm:px-6 lg:px-8 py-6 sm:py-8">
                 {% if messages %}
                     {% for message in messages %}
-                        <div class="border border-light-gray bg-white p-3 flex mb-4 rounded" role="alert">
+                        <div x-data="{ show: true }" x-show="show" class="border border-light-gray bg-white p-3 flex mb-4 rounded" role="alert">
                             <div class="mr-3">
                                 {% if message.tags == 'error' %}
                                     <i class="fa-solid fa-circle-exclamation text-black text-sm"></i>
@@ -170,7 +170,7 @@
                                 {% endif %}
                             </div>
                             <p class="text-sm flex-1">{{ message }}</p>
-                            <button class="ml-3 text-gray hover:text-black" onclick="this.parentElement.remove()">
+                            <button class="ml-3 text-gray hover:text-black" @click="show = false">
                                 <i class="fa-solid fa-xmark text-xs"></i>
                             </button>
                         </div>

--- a/templates/dashboard/home.html
+++ b/templates/dashboard/home.html
@@ -91,11 +91,16 @@
                 <i class="fa-solid fa-arrow-up-right-from-square text-gray text-xs w-4 text-center"></i>
                 <span class="text-sm text-gray group-hover:text-black">Upgrade plan</span>
             </a>
-            <a href="{% url 'dashboard:generate_api_key' %}" class="flex items-center gap-3 px-3 py-2.5 rounded hover:bg-[#fafafa] transition-colors group" onclick="event.preventDefault(); document.getElementById('api-key-form').submit();">
-                <i class="fa-solid fa-key text-gray text-xs w-4 text-center"></i>
-                <span class="text-sm text-gray group-hover:text-black">Generate API key</span>
-            </a>
-            <form id="api-key-form" action="{% url 'dashboard:generate_api_key' %}" method="POST" class="hidden">{% csrf_token %}</form>
+            {# A real form, not a link with an inline onclick: the CSP uses a
+               nonce and no unsafe-inline, and a nonce never applies to an
+               inline handler, so the old link just did a GET and got a 405. #}
+            <form action="{% url 'dashboard:generate_api_key' %}" method="POST">
+                {% csrf_token %}
+                <button type="submit" class="w-full flex items-center gap-3 px-3 py-2.5 rounded hover:bg-[#fafafa] transition-colors group text-left">
+                    <i class="fa-solid fa-key text-gray text-xs w-4 text-center"></i>
+                    <span class="text-sm text-gray group-hover:text-black">Generate API key</span>
+                </button>
+            </form>
         </div>
     </div>
 </div>

--- a/templates/subscriptions/subscription.html
+++ b/templates/subscriptions/subscription.html
@@ -8,7 +8,7 @@
   <div class="border border-light-gray p-8 mb-16">
     <h2 class="text-lg font-medium text-black uppercase tracking-wide mb-8">SUBSCRIPTION STATUS</h2>
     <p class="mb-4 text-gray">Status: <span class="font-medium text-black">{{ subscription.status }}</span></p>
-    <p class="mb-8 text-gray">Next billing date: {{ subscription.current_period_end|date:"F j, Y" }}</p>
+    <p class="mb-8 text-gray">Next billing date: {{ current_period_end|date:"F j, Y"|default:"--" }}</p>
     
     {% if subscription.status == 'active' %}
     <button id="cancelSubscription" class="px-8 py-3 border border-black text-sm font-medium uppercase tracking-wider text-black hover:bg-light-gray">
@@ -82,10 +82,27 @@
       });
       
       const data = await response.json();
-      const {error: confirmError} = await stripe.confirmCardPayment(data.client_secret);
-      
+      const errorElement = document.getElementById('card-errors');
+
+      if (data.error) {
+        errorElement.textContent = data.error;
+        return;
+      }
+
+      // A trial or a full-discount coupon leaves nothing to pay, so there is
+      // no client secret to confirm against.
+      if (!data.requires_confirmation) {
+        window.location.reload();
+        return;
+      }
+
+      const {error: confirmError} = await stripe.confirmPayment({
+        clientSecret: data.client_secret,
+        confirmParams: {return_url: window.location.href},
+        redirect: 'if_required',
+      });
+
       if (confirmError) {
-        const errorElement = document.getElementById('card-errors');
         errorElement.textContent = confirmError.message;
       } else {
         window.location.reload();


### PR DESCRIPTION
Four independent reviews of this repo. **29 → 46 tests**, ruff clean, `check --deploy` clean.

The theme: this is a public repository, so every committed default is a published value, and every defect is multiplied by whoever deploys it.

## The checkout could not work

`expand=['latest_invoice.payment_intent']` reads a field that no longer exists in current Stripe API versions, and `requirements.txt` pinned nothing, so a fresh `pip install` brought the SDK that removed it. Migrated to `latest_invoice.confirmation_secret` with the API version pinned.

Three more in the same path: the view read `request.POST['stripeToken']` with `source=` while the template posted JSON `payment_method_id`; `stripe.error.SignatureVerificationError` does not exist in v15, so a bad webhook signature answered 500 instead of 400; and `current_period_end` moved onto the subscription item and arrives as a Unix timestamp the `date` filter rendered blank.

## Paying did not grant access

`StripeCustomer.subscription_status` is written by the payment flow and read by nothing. Every gate reads `UserSettings.subscription_status`, which that flow never touched. **A customer could pay, have Stripe report the subscription as active, and stay locked out of what they had just bought.**

Cancelling had the mirror problem: it flipped a local flag and never called Stripe, so the card kept being charged for a subscription the customer believed was cancelled.

## Two holes

`subscribe_to_plan` granted any plan with no payment: a POST handed out the $49.99 tier for free. Now free plans only. The trial was restartable for ever, because an expired one makes both "is it active" checks False.

`seed_data` created a superuser with a password committed to this repository, and the deployment section told you to run it on Heroku. Generated now, and the command refuses to run with `DEBUG=False`.

## Settings failed open

`SECRET_KEY` fell back to a value committed here, with no guard. `DEBUG` defaulted to `True`, so a deployment that forgot both ran with debug pages on and a key anyone can read. Both fail closed now.

Also: `SECURE_SSL_REDIRECT` without `SECURE_PROXY_SSL_HEADER` (redirect loop behind a PaaS), the console email backend defaulting on in production, `CSRF_TRUSTED_ORIGINS` documented and never read, and `js.stripe.com` / `hooks.stripe.com` missing from the CSP, which kills any 3-D Secure challenge in silence.

## Nobody got as far as the bugs

`make install` created a virtualenv and every other target called a bare `python`, so five of nine documented commands died on a fresh clone. The README also never mentioned `python3-venv`, without which `make install` itself fails on Debian and Ubuntu.

## Left open on purpose

Entitlements, quotas, per-plan gating and multi-tenancy are still absent, and the README now says so plainly. That is not a defect in a free starter.

## Not verified

No live Stripe call. The contract is validated against the SDK surface and mocks, not a real charge.